### PR TITLE
hotfix-UC10: Voeg plus- en minknoppen toe voor aanpassen aantallen

### DIFF
--- a/Grocery.App/ViewModels/GroceryListItemsViewModel.cs
+++ b/Grocery.App/ViewModels/GroceryListItemsViewModel.cs
@@ -95,29 +95,30 @@ namespace Grocery.App.ViewModels
         }
 
         [RelayCommand]
-        public void IncreaseAmount(int productId)
+        public void IncreaseAmount(GroceryListItem item )
         {
-            GroceryListItem? item = MyGroceryListItems.FirstOrDefault(x => x.ProductId == productId);
             if (item == null) return;
+            if (item.Product == null) return;
             if (item.Amount >= item.Product.Stock) return;
+
             item.Amount++;
             _groceryListItemsService.Update(item);
+
             item.Product.Stock--;
             _productService.Update(item.Product);
-            OnGroceryListChanged(GroceryList);
         }
 
         [RelayCommand]
-        public void DecreaseAmount(int productId)
+        public void DecreaseAmount(GroceryListItem item )
         {
-            GroceryListItem? item = MyGroceryListItems.FirstOrDefault(x => x.ProductId == productId);
             if (item == null) return;
             if (item.Amount <= 0) return;
+
             item.Amount--;
             _groceryListItemsService.Update(item);
+
             item.Product.Stock++;
             _productService.Update(item.Product);
-            OnGroceryListChanged(GroceryList);
         }
     }
 }

--- a/Grocery.App/Views/GroceryListItemsView.xaml
+++ b/Grocery.App/Views/GroceryListItemsView.xaml
@@ -5,16 +5,24 @@
              xmlns:vm="clr-namespace:Grocery.App.ViewModels"
              x:Class="Grocery.App.Views.GroceryListItemsView"
              x:DataType="vm:GroceryListItemsViewModel"
-             Title="GroceryListItemsView">
+             Title="GroceryListItemsView"
+             x:Name="Root">
 
     <ContentPage.ToolbarItems>
-        <ToolbarItem Text="Wijzig kleur" Command="{Binding ChangeColorCommand}" IconImageSource="{FontImage Glyph='&#xf30c;', Color=Black, Size=22}" />
-        <ToolbarItem Text="Deel boodschappenlijst" Command="{Binding ShareGroceryListCommand}" IconImageSource="{FontImage Glyph='&#xf30c;', Color=Black, Size=22}" />
+        <ToolbarItem Text="Wijzig kleur" 
+                     Command="{Binding ChangeColorCommand}" 
+                     IconImageSource="{FontImage Glyph='&#xf30c;', Color=Black, Size=22}" />
+        <ToolbarItem Text="Deel boodschappenlijst" 
+                     Command="{Binding ShareGroceryListCommand}" 
+                     IconImageSource="{FontImage Glyph='&#xf30c;', Color=Black, Size=22}" />
     </ContentPage.ToolbarItems>
-    
+
     <Shell.TitleView>
         <Grid>
-            <Label Text="{Binding GroceryList.Name}" FontSize="Large" HorizontalOptions="Center" VerticalOptions="Center" />
+            <Label Text="{Binding GroceryList.Name}" 
+                   FontSize="Large" 
+                   HorizontalOptions="Center" 
+                   VerticalOptions="Center" />
         </Grid>
     </Shell.TitleView>
 
@@ -23,8 +31,13 @@
             <ColumnDefinition Width="4*"/>
             <ColumnDefinition Width="2*"/>
         </Grid.ColumnDefinitions>
+
+        <!-- Boodschappenlijst -->
         <Border Grid.Column="0" Stroke="#C49B33" StrokeThickness="4" Padding="10" Margin="10" HorizontalOptions="Center">
-            <CollectionView ItemsSource="{Binding MyGroceryListItems}" Margin="20" HorizontalOptions="Center" EmptyView="De boodschappenlijst is nog leeg. Voeg eerst boodschappen toe!">
+            <CollectionView ItemsSource="{Binding MyGroceryListItems}" 
+                            Margin="20" 
+                            HorizontalOptions="Center" 
+                            EmptyView="De boodschappenlijst is nog leeg. Voeg eerst boodschappen toe!">
                 <CollectionView.ItemsLayout>
                     <LinearItemsLayout Orientation="Vertical" ItemSpacing="10" />
                 </CollectionView.ItemsLayout>
@@ -35,30 +48,63 @@
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="4*"/>
                                 <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="20"/>
-                                <ColumnDefinition Width="20"/>
+                                <ColumnDefinition Width="28"/>
+                                <ColumnDefinition Width="28"/>
                             </Grid.ColumnDefinitions>
-                            <Label Grid.Column="0" Text="{Binding Product.Name}" VerticalOptions="Center"/>
-                            <Label Grid.Column="1" Text="{Binding Amount}" VerticalOptions="Center" HorizontalOptions="End" Margin="0,0,10,0"/>
-                            <Grid Grid.Column="2">
-                                <Image Source="plus.png" WidthRequest="15" HeightRequest="15"/>
-                            </Grid>
-                            <Grid Grid.Column="3">
-                                <Image Source="min.png" WidthRequest="15" HeightRequest="15"/>
-                            </Grid>
+
+                            <Label Grid.Column="0" 
+                                   Text="{Binding Product.Name}" 
+                                   VerticalOptions="Center"/>
+                            <Label Grid.Column="1" 
+                                   Text="{Binding Amount}" 
+                                   VerticalOptions="Center" 
+                                   HorizontalOptions="End" 
+                                   Margin="0,0,10,0"/>
+
+                            <!-- PLUS knop -->
+                            <ImageButton Grid.Column="2"
+                                         WidthRequest="28"
+                                         HeightRequest="28"
+                                         BackgroundColor="Transparent"
+                                         Padding="0"
+                                         Command="{Binding Source={x:Reference Root}, Path=BindingContext.IncreaseAmountCommand}"
+                                         CommandParameter="{Binding .}">
+                                <ImageButton.Source>
+                                    <FontImageSource Glyph="+" Size="20" Color="Black"/>
+                                </ImageButton.Source>
+                            </ImageButton>
+
+                            <!-- MIN knop -->
+                            <ImageButton Grid.Column="3"
+                                         WidthRequest="28"
+                                         HeightRequest="28"
+                                         BackgroundColor="Transparent"
+                                         Padding="0"
+                                         Command="{Binding Source={x:Reference Root}, Path=BindingContext.DecreaseAmountCommand}"
+                                         CommandParameter="{Binding .}">
+                                <ImageButton.Source>
+                                    <FontImageSource Glyph="−" Size="20" Color="Black"/>
+                                </ImageButton.Source>
+                            </ImageButton>
                         </Grid>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>
             </CollectionView>
         </Border>
 
+        <!-- Productenlijst -->
         <Border Grid.Row="1" Grid.Column="1" Stroke="#C49B33" StrokeThickness="4" Padding="5" Margin="5" HorizontalOptions="Center">
             <StackLayout>
-                <SearchBar x:Name="searchBar" SearchCommand="{Binding PerformSearchCommand}" SearchCommandParameter="{Binding Text, Source={x:Reference searchBar}}"/>
-                <CollectionView ItemsSource="{Binding AvailableProducts}" Margin="5" WidthRequest="300" HorizontalOptions="Start"
-            SelectionMode="Single"
-            SelectionChangedCommand="{Binding AddProductCommand}"
-            SelectionChangedCommandParameter="{Binding Source={RelativeSource Self}, Path=SelectedItem}">
+                <SearchBar x:Name="searchBar" 
+                           SearchCommand="{Binding PerformSearchCommand}" 
+                           SearchCommandParameter="{Binding Text, Source={x:Reference searchBar}}"/>
+                <CollectionView ItemsSource="{Binding AvailableProducts}" 
+                                Margin="5" 
+                                WidthRequest="300" 
+                                HorizontalOptions="Start"
+                                SelectionMode="Single"
+                                SelectionChangedCommand="{Binding AddProductCommand}"
+                                SelectionChangedCommandParameter="{Binding Source={RelativeSource Self}, Path=SelectedItem}">
                     <CollectionView.ItemsLayout>
                         <LinearItemsLayout Orientation="Vertical" ItemSpacing="10" />
                     </CollectionView.ItemsLayout>
@@ -69,21 +115,35 @@
                                     <ColumnDefinition Width="3*"/>
                                     <ColumnDefinition Width="*"/>
                                 </Grid.ColumnDefinitions>
-                                <Label Grid.Column="0" Text="{Binding Name}" VerticalOptions="Center"/>
-                                <Label Grid.Column="1" Text="{Binding Stock}" VerticalOptions="Center" HorizontalOptions="End" Margin="0,0,10,0"/>
+                                <Label Grid.Column="0" 
+                                       Text="{Binding Name}" 
+                                       VerticalOptions="Center"/>
+                                <Label Grid.Column="1" 
+                                       Text="{Binding Stock}" 
+                                       VerticalOptions="Center" 
+                                       HorizontalOptions="End" 
+                                       Margin="0,0,10,0"/>
                             </Grid>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>
                     <CollectionView.EmptyView>
                         <ContentView>
                             <VerticalStackLayout HorizontalOptions="Center" VerticalOptions="Center">
-                                <Label Text="Er zijn geen producten meer om toe te voegen" FontAttributes="Bold" HorizontalTextAlignment="Center"/>
+                                <Label Text="Er zijn geen producten meer om toe te voegen" 
+                                       FontAttributes="Bold" 
+                                       HorizontalTextAlignment="Center"/>
                             </VerticalStackLayout>
                         </ContentView>
                     </CollectionView.EmptyView>
                 </CollectionView>
             </StackLayout>
         </Border>
-        <Label Grid.Row="0" Grid.Column="0" HorizontalOptions="Center" x:Name="Message" Text="{Binding MyMessage}" TextColor="Red" Margin="30,0,0,10"/>
+
+        <Label Grid.Row="0" Grid.Column="0" 
+               HorizontalOptions="Center" 
+               x:Name="Message" 
+               Text="{Binding MyMessage}" 
+               TextColor="Red" 
+               Margin="30,0,0,10"/>
     </Grid>
 </ContentPage>

--- a/Grocery.Core/Models/GroceryListItem.cs
+++ b/Grocery.Core/Models/GroceryListItem.cs
@@ -1,17 +1,33 @@
-﻿namespace Grocery.Core.Models
+﻿using System.ComponentModel;
+
+namespace Grocery.Core.Models
 {
-    public class GroceryListItem : Model
+    public class GroceryListItem : Model, INotifyPropertyChanged
     {
         public int GroceryListId { get; set; }
         public int ProductId { get; set; }
-        public int Amount { get; set; }
+
+        private int _amount;
+        public int Amount
+        {
+            get => _amount;
+            set
+            {
+                if (_amount == value) return;
+                _amount = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Amount)));
+            }
+        }
+
+        public Product Product { get; set; } = new(0, "None", 0);
+
         public GroceryListItem(int id, int groceryListId, int productId, int amount) : base(id, "")
         {
             GroceryListId = groceryListId;
             ProductId = productId;
-            Amount = amount;
+            _amount = amount; // gebruik backing field
         }
 
-        public Product Product { get; set; } = new(0, "None", 0);
+        public event PropertyChangedEventHandler? PropertyChanged;
     }
 }


### PR DESCRIPTION
Knoppen product aantal verhogen & verlagen in boodschappenlijst niet werkend,
Hieronder staat wat er is veranderd om dit werkend te krijgen.

- Implementatie van knoppen bij boodschappenlijstitems (UC10)
- ImageButtons vervangen door FontImageSource (+ en −) voor consistente weergave
- Koppeling gemaakt met IncreaseAmountCommand en DecreaseAmountCommand
- Layout verbeterd: knoppen netjes gecentreerd en uniforme grootte